### PR TITLE
Add DOI to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![DOI](https://zenodo.org/badge/DOI/10.5281/zenodo.13328681.svg)](https://doi.org/10.5281/zenodo.13328681)
+
 # CFReT Project
 
 In this repository, we generate pipelines to perform image analysis, image-based profiling, and training machine learning model to predict cardiac fibrosis phenotype.


### PR DESCRIPTION
# Add DOI to README

In this short PR, the DOI generated by Zenodo after minting this repo is added to the main README.